### PR TITLE
Fixed the adding of brackets when changing nodes to string

### DIFF
--- a/toolRules.test.js
+++ b/toolRules.test.js
@@ -272,7 +272,7 @@ test('complex reverse or associativity - applied to give (a∧c)∨((b∧c)∨c)
   let formula = toolRules.buildTreeFromString('((a∧c)∨(b∧c))∨c');
   let afterAssociativity = toolRules.applyRule(formula, 'associativity');
   let asString = toolRules.convertTreeToString(afterAssociativity);
-  expect(asString).toBe('(a∧c)∨((b∧c)∨c)');
+  expect(asString).toBe('a∧c∨(b∧c∨c)');
 });
 
 // DISTRIBUTIVITY TESTS


### PR DESCRIPTION
Changed the way brackets are added so that if they're needed the brackets are added before calling addNodeToString with the child nodes.